### PR TITLE
Workaround for recycler view list item click feedback

### DIFF
--- a/sample/src/main/java/com/hudomju/swipe/sample/RecyclerViewActivity.java
+++ b/sample/src/main/java/com/hudomju/swipe/sample/RecyclerViewActivity.java
@@ -50,6 +50,7 @@ public class RecyclerViewActivity extends Activity {
                         });
 
         recyclerView.setOnTouchListener(touchListener);
+//        touchListener.setSelectableItemBackgroundOnItemClick(R.id.txt_data);
         // Setting this scroll listener is required to ensure that during ListView scrolling,
         // we don't look for swipes.
         recyclerView.setOnScrollListener((RecyclerView.OnScrollListener) touchListener.makeScrollListener());
@@ -57,6 +58,7 @@ public class RecyclerViewActivity extends Activity {
                 new OnItemClickListener() {
                     @Override
                     public void onItemClick(View view, int position) {
+                        touchListener.setSelectableItemBackgroundOnItemClick(view);
                         if (view.getId() == R.id.txt_delete) {
                             touchListener.processPendingDismisses();
                         } else if (view.getId() == R.id.txt_undo) {


### PR DESCRIPTION
Created dirty workaround in the library for item click feedback. 
Line : touchListener.setSelectableItemBackgroundOnItemClick(view);  <-- needs to be added in onItemClick.

recyclerView.addOnItemTouchListener(new SwipeableItemClickListener(this,
                new OnItemClickListener() {
                    @Override
                    public void onItemClick(View view, int position) {
                        touchListener.setSelectableItemBackgroundOnItemClick(view);
                        if (view.getId() == R.id.txt_delete) {
                            touchListener.processPendingDismisses();
                        } else if (view.getId() == R.id.txt_undo) {
                            touchListener.undoPendingDismiss();
                        } else { // R.id.txt_data
                            Toast.makeText(RecyclerViewActivity.this, "Position " + position, LENGTH_SHORT).show();
                        }
                    }
                }));
