### PR TITLE
squid:UselessParenthesesCheck - Useless parentheses around expression…

### DIFF
--- a/library/src/main/java/com/hudomju/swipe/SwipeToDismissTouchListener.java
+++ b/library/src/main/java/com/hudomju/swipe/SwipeToDismissTouchListener.java
@@ -238,8 +238,8 @@ public class SwipeToDismissTouchListener<SomeCollectionView extends ViewAdapter>
                     child = mRecyclerView.getChildAt(i);
                     child.getHitRect(rect);
                     if (rect.contains(x, y)) {
-                        assert(child instanceof ViewGroup &&
-                                ((ViewGroup) child).getChildCount() == 2) :
+                        assert child instanceof ViewGroup &&
+                                ((ViewGroup) child).getChildCount() == 2 :
                                 "Each child needs to extend from ViewGroup and have two children";
 
                         boolean dataContainerHasBeenDismissed = mPendingDismiss != null &&
@@ -355,7 +355,7 @@ public class SwipeToDismissTouchListener<SomeCollectionView extends ViewAdapter>
                 float deltaY = motionEvent.getRawY() - mDownY;
                 if (Math.abs(deltaX) > mSlop && Math.abs(deltaY) < Math.abs(deltaX) / 2) {
                     mSwiping = true;
-                    mSwipingSlop = (deltaX > 0 ? mSlop : -mSlop);
+                    mSwipingSlop = deltaX > 0 ? mSlop : -mSlop;
                     mRecyclerView.requestDisallowInterceptTouchEvent(true);
 
                     // Cancel ListView's touch (un-highlighting the item)

--- a/library/src/main/java/com/hudomju/swipe/SwipeableItemClickListener.java
+++ b/library/src/main/java/com/hudomju/swipe/SwipeableItemClickListener.java
@@ -49,7 +49,7 @@ public class SwipeableItemClickListener implements RecyclerView.OnItemTouchListe
         while (childView instanceof ViewGroup && v != null) {
             x -= childView.getLeft();
             y -= childView.getTop();
-            v = findChildViewUnder(((ViewGroup) childView), x, y);
+            v = findChildViewUnder((ViewGroup) childView, x, y);
             if (v != null) {
                 childView = v;
             }

--- a/sample/src/main/java/com/hudomju/swipe/sample/ListViewActivity.java
+++ b/sample/src/main/java/com/hudomju/swipe/sample/ListViewActivity.java
@@ -105,7 +105,7 @@ public class ListViewActivity extends Activity {
         static class ViewHolder {
             TextView dataTextView;
             ViewHolder(View view) {
-                dataTextView = ((TextView) view.findViewById(R.id.txt_data));
+                dataTextView = (TextView) view.findViewById(R.id.txt_data);
                 view.setTag(this);
             }
         }

--- a/sample/src/main/java/com/hudomju/swipe/sample/RecyclerViewActivity.java
+++ b/sample/src/main/java/com/hudomju/swipe/sample/RecyclerViewActivity.java
@@ -112,7 +112,7 @@ public class RecyclerViewActivity extends Activity {
             TextView dataTextView;
             MyViewHolder(View view) {
                 super(view);
-                dataTextView = ((TextView) view.findViewById(R.id.txt_data));
+                dataTextView = (TextView) view.findViewById(R.id.txt_data);
             }
         }
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:UselessParenthesesCheck

Please let me know if you have any questions.

M-Ezzat
